### PR TITLE
fix(systemd): remove invalid Alias from service template

### DIFF
--- a/templates/app@.service.j2
+++ b/templates/app@.service.j2
@@ -51,4 +51,3 @@ TimeoutStopSec=10s
 
 [Install]
 WantedBy=multi-user.target
-Alias={{ cartridge_app_name }}.%i


### PR DESCRIPTION
Since systemd 240, strict validation prevents template units (with '@') from having aliases without the '@' sign. Removing this line fixes the first-run Ansible failures.